### PR TITLE
Update gpt_roulette.ex

### DIFF
--- a/lib/gpt_roulette.ex
+++ b/lib/gpt_roulette.ex
@@ -1,18 +1,31 @@
 defmodule GptRoulette do
   @moduledoc """
-  Documentation for `GptRoulette`.
+  Sigil CHATGPT library for interacting with the OpenAI GPT-3 API.
   """
 
-  @doc """
-  Hello world.
+  @base_url "https://api.openai.com"
+  @api_key Application.compile_env(:chat_gpt, :api_key)
 
-  ## Examples
+  defmacro sigil_CHATGPT(string, []) do
+    compile_suggestion(String.to_char_list(string))
+  end
 
-      iex> GptRoulette.hello()
-      :world
+  defp compile_suggestion(prompt) do
+    {:ok, response} = HTTPoison.post(
+      "#{@base_url}/v1/engines/davinci-codex/completions",
+      %{
+        "prompt" => prompt,
+        "max_tokens" => 100,
+        "temperature" => 0.7
+      },
+      headers: [
+        {"Authorization", "Bearer #{@api_key}"},
+        {"Content-Type", "application/json"}
+      ]
+    )
 
-  """
-  def hello do
-    :world
+    result = Jason.decode!(response.body)
+    suggestion = result["choices"][0]["text"]
+    String.to_existing_atom(suggestion)
   end
 end


### PR DESCRIPTION
Creating a full-fledged Elixir library for interacting with ChatGPT is beyond the scope of a simple response. However, I can provide you with an outline of how you can define an Elixir sigil called CHATGPT that compiles ChatGPT suggestions using OpenAI's API. For this example, I assume you already have an API key or other credentials to access the ChatGPT API.